### PR TITLE
[NETBEANS-3332] Update plugin version to 4.4

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -43,7 +43,7 @@
                 <plugin>
                     <groupId>org.apache.netbeans.utilities</groupId>
                     <artifactId>nbm-maven-plugin</artifactId>
-                    <version>4.3</version>
+                    <version>4.4</version>
                     <configuration>
                         <cluster>${artifactId.toLowerCase().replaceAll("[^a-z0-9_]+", "_")}</cluster>
                     </configuration>


### PR DESCRIPTION
Update nbm-maven-plugin to 4.4 which fixes installer builds with Java 11+

Related to https://issues.apache.org/jira/browse/NETBEANS-2863